### PR TITLE
Add team specific configuration

### DIFF
--- a/db/create.sql
+++ b/db/create.sql
@@ -5,9 +5,14 @@ DROP TABLE members;
 DROP TABLE teams;
 DROP TABLE shifts;
 
+
+-- days_in_shift: The days included in a shift table
+-- max_shift_count_in_routine: The max shift tables generated in one routine
 CREATE TABLE IF NOT EXISTS teams(
   id bigserial PRIMARY KEY,
-  name varchar(80)
+  name varchar(80),
+  days_in_shift bigint,
+  max_shift_count_in_routine bigint
 );
 
 CREATE TABLE IF NOT EXISTS members(

--- a/db/testData.sql
+++ b/db/testData.sql
@@ -1,3 +1,74 @@
-INSERT INTO teams (id, name) VALUES(1, 'nobitanian');
+-- Test data initialization
+INSERT INTO teams (id, name, days_in_shift, max_shift_count_in_routine) VALUES(1, 'nobitanian', 7, 1);
 INSERT INTO members (id, name, line_id, team) VALUES(1, 'gologo13', 'dummy', 1);
 INSERT INTO members (id, name, line_id, team) VALUES(2, 'Kai', 'dummy', 1);
+INSERT INTO members (id, name, line_id, team) VALUES(3, 'Shoe', 'dummy', 1);
+
+-- gologo13's requests
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(1, 1,
+  timestamp '2017-01-01 08:00:00',
+  timestamp '2017-01-01 08:00:00' + interval '3 hours',
+  0.9
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(1, 1,
+  timestamp '2017-01-01 12:00:00',
+  timestamp '2017-01-01 12:00:00' + interval '3 hours',
+  0.2
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(1, 1,
+  timestamp '2017-01-01 17:00:00',
+  timestamp '2017-01-01 17:00:00' + interval '3 hours',
+  0.5
+);
+
+-- Kai's requests
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(2, 1,
+  timestamp '2017-01-01 08:00:00',
+  timestamp '2017-01-01 08:00:00' + interval '3 hours',
+  0.2
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(2, 1,
+  timestamp '2017-01-01 12:00:00',
+  timestamp '2017-01-01 12:00:00' + interval '3 hours',
+  0.1
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(2, 1,
+  timestamp '2017-01-01 17:00:00',
+  timestamp '2017-01-01 17:00:00' + interval '3 hours',
+  0.4
+);
+
+-- Shoe's requests
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(3, 1,
+  timestamp '2017-01-01 08:00:00',
+  timestamp '2017-01-01 08:00:00' + interval '3 hours',
+  0.9
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(3, 1,
+  timestamp '2017-01-01 12:00:00',
+  timestamp '2017-01-01 12:00:00' + interval '3 hours',
+  0.8
+);
+INSERT INTO
+  requests (member, team, start_time, end_time, availability)
+VALUES(3, 1,
+  timestamp '2017-01-01 17:00:00',
+  timestamp '2017-01-01 17:00:00' + interval '3 hours',
+  0.7
+);


### PR DESCRIPTION
Add two team specific configuration as discussed in Slack.
- `daily_in_shift` : specifies the days included in a shift table.
- `max_shift_count_in_rountine`: specifies the number of shift tables generated by one batch routine.

And enrich test data. ref: #14 
