### PR TITLE
Specify start date of each shift table

### DIFF
--- a/db/create.sql
+++ b/db/create.sql
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS requests(
 
 CREATE TABLE IF NOT EXISTS shifts(
   id bigserial PRIMARY KEY,
-  start_time timestamp,
-  end_time timestamp,
+  team bigint references teams(id),
+  start_date date,
   time_table json
 );


### PR DESCRIPTION
`start_date` specifies the first date of this shift table. This is usually same to the first day of week(Monday or Sunday)
